### PR TITLE
Bugfixes and enhancements to the crm provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,9 +120,9 @@ cs_order { 'vip_before_service':
 }
 ```
 
-Crosync Properties
+Corosync Properties
 ------------------
-A few gloabal settings can be changed with the "cs_property" section.
+A few global settings can be changed with the "cs_property" section.
 
 
 Disable STONITH if required.

--- a/lib/puppet/provider/cs_clone/crm.rb
+++ b/lib/puppet/provider/cs_clone/crm.rb
@@ -55,15 +55,16 @@ Puppet::Type.type(:cs_clone).provide(:crm, :parent => Puppet::Provider::Crmsh) d
       :ensure     => :present,
       :primitive  => @resource[:primitive],
       :metadata   => @resource[:metadata],
+      :cib        => @resource[:cib],
     }
-    @property_hash[:cib] = @resource[:cib] if ! @resource[:cib].nil?
+    debug("created cs_clone: #{@property_hash.inspect}")
   end
 
   
   def destroy
     debug('Stopping primitive before removing it')
     crm('resource', 'stop', @resource[:name])
-    debug('Revmoving primitive')
+    debug('Removing primitive')
     crm('configure', 'delete', @resource[:name])
     @property_hash.clear
   end
@@ -102,6 +103,7 @@ Puppet::Type.type(:cs_clone).provide(:crm, :parent => Puppet::Provider::Crmsh) d
         tmpfile.write(updated)
         tmpfile.flush
         ENV['CIB_shadow'] = @resource[:cib]
+        debug("Sending to crm (with CIB_shadow=#{ENV['CIB_shadow']}): '#{updated}'")
         crm('configure', 'load', 'update', tmpfile.path.to_s)
       end
     end

--- a/lib/puppet/provider/cs_clone/crm.rb
+++ b/lib/puppet/provider/cs_clone/crm.rb
@@ -1,0 +1,111 @@
+require 'pathname'
+require Pathname.new(__FILE__).dirname.dirname.expand_path + 'crmsh'
+
+Puppet::Type.type(:cs_clone).provide(:crm, :parent => Puppet::Provider::Crmsh) do
+  desc ' Fill this in '
+
+  # Path to the crm binary for interacting with the cluster configuration.
+  commands :crm => 'crm'
+
+  # given an XML element containing some <nvpair>s, return a hash. Return an
+  # empty hash if `e` is nil.
+  def self.nvpairs_to_hash(e)
+    return {} if e.nil?
+
+    hash = {}
+    e.each_element do |i|
+      hash[(i.attributes['name'])] = i.attributes['value']
+    end
+
+    hash
+  end
+
+  def self.instances
+
+    block_until_ready
+
+    instances = []
+
+    cmd = [ command(:crm), 'configure', 'show', 'xml' ]
+    if Puppet::PUPPETVERSION.to_f < 3.4
+      raw, status = Puppet::Util::SUIDManager.run_and_capture(cmd)
+    else
+      raw = Puppet::Util::Execution.execute(cmd)
+      status = raw.exitstatus
+    end
+    doc = REXML::Document.new(raw)
+
+    doc.root.elements['configuration'].elements['resources'].each_element('clone') do |e|
+      clone_instance = {
+        :name      => e.attributes['id'].to_sym,
+        :metadata  => nvpairs_to_hash(e.elements['meta_attributes']),
+        :primitive => e.elements['primitive'].attributes['id'].to_sym,
+      }
+
+      instances << new(clone_instance)
+    end
+
+    instances
+  end
+
+  
+  def create
+    @property_hash = {
+      :name       => @resource[:name],
+      :ensure     => :present,
+      :primitive  => @resource[:primitive],
+      :metadata   => @resource[:metadata],
+    }
+    @property_hash[:cib] = @resource[:cib] if ! @resource[:cib].nil?
+  end
+
+  
+  def destroy
+    debug('Stopping primitive before removing it')
+    crm('resource', 'stop', @resource[:name])
+    debug('Revmoving primitive')
+    crm('configure', 'delete', @resource[:name])
+    @property_hash.clear
+  end
+
+
+  def primitive
+    @property_hash[:primitive]
+  end
+
+  
+  def primitive=(should)
+    @property_hash[:primitive] = should
+  end
+
+  
+  def metadata
+    @property_hash[:metadata]
+  end
+
+
+  def metadata=(should)
+    @property_hash[:metadata] = should
+  end
+
+  def flush
+    unless @property_hash.empty?
+      updated = 'clone '
+      updated << "#{@property_hash[:name]} #{@property_hash[:primitive]} "
+      unless @property_hash[:metadata].empty?
+        updated << 'meta '
+        @property_hash[:metadata].each do |k,v|
+          updated << "#{k}=#{v} "
+        end
+      end
+      Tempfile.open('puppet_crm_update') do |tmpfile|
+        tmpfile.write(updated)
+        tmpfile.flush
+        ENV['CIB_shadow'] = @resource[:cib]
+        crm('configure', 'load', 'update', tmpfile.path.to_s)
+      end
+    end
+  end
+
+end
+

--- a/lib/puppet/provider/cs_commit/pcs.rb
+++ b/lib/puppet/provider/cs_commit/pcs.rb
@@ -2,6 +2,8 @@ require 'pathname'
 require Pathname.new(__FILE__).dirname.dirname.expand_path + 'pacemaker'
 
 Puppet::Type.type(:cs_commit).provide(:pcs, :parent => Puppet::Provider::Pacemaker) do
+  defaultfor :operatingsystem => [:fedora, :centos, :redhat]
+
   commands :crm_shadow => 'crm_shadow'
 
   def self.instances

--- a/lib/puppet/provider/cs_location/crm.rb
+++ b/lib/puppet/provider/cs_location/crm.rb
@@ -19,7 +19,12 @@ Puppet::Type.type(:cs_location).provide(:crm, :parent => Puppet::Provider::Crmsh
     instances = []
 
     cmd = [ command(:crm), 'configure', 'show', 'xml' ]
-    raw, status = Puppet::Util::SUIDManager.run_and_capture(cmd)
+    if Puppet::PUPPETVERSION.to_f < 3.4
+      raw, status = Puppet::Util::SUIDManager.run_and_capture(cmd)
+    else
+      raw = Puppet::Util::Execution.execute(cmd)
+      status = raw.exitstatus
+    end
     doc = REXML::Document.new(raw)
 
     doc.root.elements['configuration'].elements['constraints'].each_element('rsc_location') do |e|

--- a/lib/puppet/provider/cs_location/crm.rb
+++ b/lib/puppet/provider/cs_location/crm.rb
@@ -1,7 +1,7 @@
 require 'pathname'
-require Pathname.new(__FILE__).dirname.dirname.expand_path + 'corosync'
+require Pathname.new(__FILE__).dirname.dirname.expand_path + 'crmsh'
 
-Puppet::Type.type(:cs_location).provide(:crm, :parent => Puppet::Provider::Corosync) do
+Puppet::Type.type(:cs_location).provide(:crm, :parent => Puppet::Provider::Crmsh) do
   desc 'Specific provider for a rather specific type since I currently have no plan to
         abstract corosync/pacemaker vs. keepalived.  This provider will check the state
         of current primitive locations on the system; add, delete, or adjust various

--- a/lib/puppet/provider/cs_location/crm.rb
+++ b/lib/puppet/provider/cs_location/crm.rb
@@ -34,7 +34,7 @@ Puppet::Type.type(:cs_location).provide(:crm, :parent => Puppet::Provider::Crmsh
         :name       => items['id'],
         :ensure     => :present,
         :primitive  => items['rsc'],
-        :node_name  => items['node_name'],
+        :node_name  => items['node'],
         :score      => items['score'],
         :provider   => self.name
       }

--- a/lib/puppet/provider/cs_primitive/crm.rb
+++ b/lib/puppet/provider/cs_primitive/crm.rb
@@ -26,6 +26,42 @@ Puppet::Type.type(:cs_primitive).provide(:crm, :parent => Puppet::Provider::Crms
     hash
   end
 
+  def self.operations_to_hash(e)
+    return {} if e.nil?
+    
+    hash = {}
+
+    e.each_element do |op|
+    
+      # Extract the name
+      operation_name = op.attributes['name']
+      if hash[operation_name].nil?
+        hash[operation_name] = []
+      end
+
+      # Populate a hash with its attributes
+      operation = {}
+      op.attributes.each do |operation_attribute_name, operation_attribute_value|
+        # id we don't care about. name we already have.
+        next if operation_attribute_name == 'id'
+        next if operation_attribute_name == 'name'
+
+        operation[operation_attribute_name] = operation_attribute_value
+      end
+
+      # Pull out the instance attributes too if there are any
+      unless op.elements['instance_attributes'].nil?
+        op.elements['instance_attributes'].each_element do |ia|
+          operation[ia.attributes['name']] = ia.attributes['value']
+        end
+      end
+
+      hash[operation_name] << operation
+    end
+
+    hash
+  end
+
   # given an XML element (a <primitive> from cibadmin), produce a hash suitible
   # for creating a new provider instance.
   def self.element_to_hash(e)
@@ -37,27 +73,13 @@ Puppet::Type.type(:cs_primitive).provide(:crm, :parent => Puppet::Provider::Crms
       :ensure           => :present,
       :provider         => self.name,
       :parameters       => nvpairs_to_hash(e.elements['instance_attributes']),
-      :operations       => {},
+      :operations       => operations_to_hash(e.elements['operations']),
       :utilization      => nvpairs_to_hash(e.elements['utilization']),
       :metadata         => nvpairs_to_hash(e.elements['meta_attributes']),
       :ms_metadata      => {},
       :promotable       => :false
     }
 
-    if ! e.elements['operations'].nil?
-      e.elements['operations'].each_element do |o|
-        valids = o.attributes.reject do |k,v| k == 'id' end
-        hash[:operations][valids['name']] = {}
-        valids.each do |k,v|
-          hash[:operations][valids['name']][k] = v if k != 'name'
-        end
-        if ! o.elements['instance_attributes'].nil?
-          o.elements['instance_attributes'].each_element do |i|
-            hash[:operations][valids['name']][(i.attributes['name'])] = i.attributes['value']
-          end
-        end
-      end
-    end
     if e.parent.name == 'master'
       hash[:promotable] = :true
       if ! e.parent.elements['meta_attributes'].nil?

--- a/lib/puppet/provider/cs_primitive/crm.rb
+++ b/lib/puppet/provider/cs_primitive/crm.rb
@@ -193,26 +193,26 @@ Puppet::Type.type(:cs_primitive).provide(:crm, :parent => Puppet::Provider::Crms
         operations = ''
         @property_hash[:operations].each do |o|
           operations << "op #{o[0]} "
-          o[1].each_pair do |k,v|
+          o[1].each do |k,v|
             operations << "#{k}=#{v} "
           end
         end
       end
       unless @property_hash[:parameters].empty?
         parameters = 'params '
-        @property_hash[:parameters].each_pair do |k,v|
+        @property_hash[:parameters].each do |k,v|
           parameters << "#{k}=#{v} "
         end
       end
       unless @property_hash[:utilization].empty?
         utilization = 'utilization '
-        @property_hash[:utilization].each_pair do |k,v|
+        @property_hash[:utilization].each do |k,v|
           utilization << "#{k}=#{v} "
         end
       end
       unless @property_hash[:metadata].empty?
         metadatas = 'meta '
-        @property_hash[:metadata].each_pair do |k,v|
+        @property_hash[:metadata].each do |k,v|
           metadatas << "#{k}=#{v} "
         end
       end
@@ -229,7 +229,7 @@ Puppet::Type.type(:cs_primitive).provide(:crm, :parent => Puppet::Provider::Crms
         updated << "ms ms_#{@property_hash[:name]} #{@property_hash[:name]} "
         unless @property_hash[:ms_metadata].empty?
           updated << 'meta '
-          @property_hash[:ms_metadata].each_pair do |k,v|
+          @property_hash[:ms_metadata].each do |k,v|
             updated << "#{k}=#{v} "
           end
         end

--- a/lib/puppet/provider/cs_primitive/crm.rb
+++ b/lib/puppet/provider/cs_primitive/crm.rb
@@ -192,9 +192,18 @@ Puppet::Type.type(:cs_primitive).provide(:crm, :parent => Puppet::Provider::Crms
       unless @property_hash[:operations].empty?
         operations = ''
         @property_hash[:operations].each do |o|
-          operations << "op #{o[0]} "
-          o[1].each do |k,v|
-            operations << "#{k}=#{v} "
+          if o[1].is_a?(Hash)
+            operations << "op #{o[0]} "
+            o[1].each_pair do |k,v|
+              operations << "#{k}=#{v} "
+            end
+          elsif o[1].is_a?(Array)
+            o[1].each do |p|
+              operations << "op #{o[0]} "
+              p.each_pair do |k,v|
+                operations << "#{k}=#{v} "
+              end
+            end
           end
         end
       end

--- a/lib/puppet/provider/cs_primitive/pcs.rb
+++ b/lib/puppet/provider/cs_primitive/pcs.rb
@@ -232,26 +232,26 @@ Puppet::Type.type(:cs_primitive).provide(:pcs, :parent => Puppet::Provider::Pace
           else
             operations << op_name
           end
-          o[1].each_pair do |k,v|
+          o[1].each do |k,v|
             operations << "#{k}=#{v}"
           end
         end
       end
       unless @property_hash[:parameters].empty?
         parameters = []
-        @property_hash[:parameters].each_pair do |k,v|
+        @property_hash[:parameters].each do |k,v|
           parameters << "#{k}=#{v}"
         end
       end
       unless @property_hash[:utilization].empty?
         utilization = [ 'utilization' ]
-        @property_hash[:utilization].each_pair do |k,v|
+        @property_hash[:utilization].each do |k,v|
           utilization << "#{k}=#{v}"
         end
       end
       unless @property_hash[:metadata].empty?
         metadatas = [ 'meta' ]
-        @property_hash[:metadata].each_pair do |k,v|
+        @property_hash[:metadata].each do |k,v|
           metadatas << "#{k}=#{v}"
         end
       end
@@ -284,7 +284,7 @@ Puppet::Type.type(:cs_primitive).provide(:pcs, :parent => Puppet::Provider::Pace
           cmd = [ command(:pcs), 'resource', 'master', "ms_#{@property_hash[:name]}", "#{@property_hash[:name]}" ]
           unless @property_hash[:ms_metadata].empty?
             cmd << 'meta'
-            @property_hash[:ms_metadata].each_pair do |k,v|
+            @property_hash[:ms_metadata].each do |k,v|
               cmd << "#{k}=#{v}"
             end
           end
@@ -301,7 +301,7 @@ Puppet::Type.type(:cs_primitive).provide(:pcs, :parent => Puppet::Provider::Pace
           @property_hash[:existing_operations].each do |o|
             cmd = [ command(:pcs), 'resource', 'op', 'remove', "#{@property_hash[:name]}" ]
             cmd << "#{o[0]}"
-            o[1].each_pair do |k,v|
+            o[1].each do |k,v|
               cmd << "#{k}=#{v}"
             end
             Puppet::Provider::Pacemaker::run_pcs_command(cmd)
@@ -317,7 +317,7 @@ Puppet::Type.type(:cs_primitive).provide(:pcs, :parent => Puppet::Provider::Pace
           cmd = [ command(:pcs), 'resource', 'update', "ms_#{@property_hash[:name]}", "#{@property_hash[:name]}" ]
           unless @property_hash[:ms_metadata].empty?
             cmd << 'meta'
-            @property_hash[:ms_metadata].each_pair do |k,v|
+            @property_hash[:ms_metadata].each do |k,v|
               cmd << "#{k}=#{v}"
             end
           end

--- a/lib/puppet/provider/cs_shadow/pcs.rb
+++ b/lib/puppet/provider/cs_shadow/pcs.rb
@@ -2,6 +2,8 @@ require 'pathname'
 require Pathname.new(__FILE__).dirname.dirname.expand_path + 'pacemaker'
 
 Puppet::Type.type(:cs_shadow).provide(:pcs, :parent => Puppet::Provider::Pacemaker) do
+  defaultfor :operatingsystem => [:fedora, :centos, :redhat]
+
   commands :crm_shadow => 'crm_shadow'
 
   def self.instances

--- a/lib/puppet/type/cs_clone.rb
+++ b/lib/puppet/type/cs_clone.rb
@@ -1,0 +1,51 @@
+module Puppet
+  newtype(:cs_clone) do
+
+    ensurable
+
+    newparam(:name) do
+      desc "Fill this in "
+
+      isnamevar
+    end
+
+    newproperty(:primitive) do
+      desc "fill this in "
+    end
+
+    newproperty(:metadata) do 
+      desc "A hash of metadata ... "
+
+      validate do |value|
+        raise Puppet::Error, "Puppet::Type::Cs_Clone: metadata property must be a hash." unless value.is_a? Hash
+      end
+
+      defaultto Hash.new
+    end
+
+    newparam(:cib) do
+      desc "Corosync applies its configuration immediately. Using a CIB allows
+        you to group multiple primitives and relationships to be applied at
+        once. This can be necessary to insert complex configurations into
+        Corosync correctly.
+
+        This paramater sets the CIB this order should be created in. A
+        cs_shadow resource with a title of the same name as this value should
+        also be added to your manifest."
+    end
+
+    autorequire(:cs_shadow) do
+      [ @parameters[:cib] ]
+    end
+
+    autorequire(:service) do
+      [ 'corosync' ]
+    end
+
+    autorequire(:cs_primitive) do
+      [ @parameters[:primitive] ]
+    end
+
+  end
+end
+

--- a/lib/puppet/type/cs_clone.rb
+++ b/lib/puppet/type/cs_clone.rb
@@ -1,20 +1,39 @@
 module Puppet
   newtype(:cs_clone) do
+    @doc = "Type for manipulating Corosync/Pacemaker clone resources.
+      Clones are required when you have a resource that can run in more
+      than one place simultaneously, e.g. an active/active pair.
+      
+      More information can be found here:
+      http://clusterlabs.org/doc/en-US/Pacemaker/1.1/html/Pacemaker_Explained/s-resource-clone.html
+      
+      In order to declare a clone resource, you must already have a cs_primitive
+      resource to clone."
 
     ensurable
 
     newparam(:name) do
-      desc "Fill this in "
+      desc "Name identifier of this clone resource. This value needs to be unique
+        across the entire Corosync/Pacemaker configuration, since it doesn't have
+        the concept of name spaces per type."
 
       isnamevar
     end
 
     newproperty(:primitive) do
-      desc "fill this in "
+      desc "The primitive to clone."
     end
 
-    newproperty(:metadata) do 
-      desc "A hash of metadata ... "
+    newproperty(:metadata) do
+      # This would be much better expressed as multiple properties.
+      #
+      desc "A hash of metadata for the clone resource. This is effectively the resource's
+        configuration. Hash keys that you can use here are: clone-max, clone-node-max,
+        notify, globally-unique, ordered, interleave.
+
+        The options priority, target-role, and is-managed are inherited from the primitive.
+
+        For more detail, see: http://clusterlabs.org/doc/en-US/Pacemaker/1.1/html/Pacemaker_Explained/_clone_options.html"
 
       validate do |value|
         raise Puppet::Error, "Puppet::Type::Cs_Clone: metadata property must be a hash." unless value.is_a? Hash

--- a/lib/puppet/type/cs_commit.rb
+++ b/lib/puppet/type/cs_commit.rb
@@ -41,6 +41,9 @@ module Puppet
       resources_with_cib :cs_location
     end
 
+    autorequire(:cs_clone) do
+      resources_with_cib :cs_clone
+    end
 
     autorequire(:cs_order) do
       resources_with_cib :cs_order

--- a/lib/puppet/type/cs_location.rb
+++ b/lib/puppet/type/cs_location.rb
@@ -48,6 +48,10 @@ module Puppet
       [ @parameters[:cib] ]
     end
 
+    autorequire(:cs_primitive) do
+      [ self[:primitive] ]
+    end
+
     autorequire(:service) do
       [ 'corosync' ]
     end

--- a/lib/puppet/type/cs_primitive.rb
+++ b/lib/puppet/type/cs_primitive.rb
@@ -94,6 +94,19 @@ module Puppet
       end
 
       defaultto Hash.new
+
+      def is_to_s(value)
+        value.inspect
+      end
+
+      def change_to_s(current, desired)
+        "changing #{current.inspect} to #{desired.inspect}"
+      end
+
+      def should_to_s(current, desired)
+        "current value #{current.inspect}, should be #{desired.inspect}"
+      end
+
     end
 
     newproperty(:utilization) do

--- a/lib/puppet/type/cs_shadow.rb
+++ b/lib/puppet/type/cs_shadow.rb
@@ -27,7 +27,7 @@ module Puppet
     end
 
     def generate
-      options = { :name => @title }
+      options = { :name => @title, :provider => provider.class.name }
       [ Puppet::Type.type(:cs_commit).new(options) ]
     end
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -82,7 +82,7 @@
 # Copyright 2012, Puppet Labs, LLC.
 #
 class corosync(
-  $enable_secauth     = 'UNSET',
+  $enable_secauth     = true,
   $authkey_source     = 'file',
   $authkey            = '/etc/puppet/ssl/certs/ca.pem',
   $threads            = 'UNSET',
@@ -152,26 +152,12 @@ class corosync(
     $multicast_address_real = $multicast_address
   }
 
-  if $enable_secauth == 'UNSET' {
-    case $::enable_secauth {
-      true:  { $enable_secauth_real = 'on' }
-      false: { $enable_secauth_real = 'off' }
-      undef:   { $enable_secauth_real = 'on' }
-      '':      { $enable_secauth_real = 'on' }
-      default: { validate_re($::enable_secauth, '^true$|^false$') }
-    }
-  } else {
-      case $enable_secauth {
-        true:   { $enable_secauth_real = 'on' }
-        false:  { $enable_secauth_real = 'off' }
-        default: { fail('The enable_secauth class parameter requires a true or false boolean') }
-      }
-  }
+  $enable_secauth_real = str2bool($enable_secauth)
 
   # Using the Puppet infrastructure's ca as the authkey, this means any node in
   # Puppet can join the cluster.  Totally not ideal, going to come up with
   # something better.
-  if $enable_secauth_real == 'on' {
+  if $enable_secauth_real {
     case $authkey_source {
       'file': {
         file { '/etc/corosync/authkey':
@@ -269,4 +255,5 @@ class corosync(
     enable    => true,
     subscribe => File[ [ '/etc/corosync/corosync.conf', '/etc/corosync/service.d' ] ],
   }
+
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -233,12 +233,6 @@ class corosync(
   }
 
   case $::osfamily {
-    'RedHat': {
-      exec { 'enable corosync':
-        require => Package['corosync'],
-        before  => Service['corosync'],
-      }
-    }
     'Debian': {
       exec { 'enable corosync':
         command => 'sed -i s/START=no/START=yes/ /etc/default/corosync',

--- a/spec/unit/puppet/provider/cs_primitive_crm_spec.rb
+++ b/spec/unit/puppet/provider/cs_primitive_crm_spec.rb
@@ -89,9 +89,9 @@ describe Puppet::Type.type(:cs_primitive).provider(:crm) do
 
       it 'has an operations property corresponding to <operations>' do
         expect(instance.operations).to eq({
-          "monitor" => {"interval" => "15", "timeout" => "10", "on-fail" => "standby", "OCF_CHECK_LEVEL" => "10"},
-          "start" => {"interval" => "0", "timeout" => "60"},
-          "stop" => {"interval" => "0", "timeout" => "40"},
+          "monitor" => [ {"interval" => "15", "timeout" => "10", "on-fail" => "standby", "OCF_CHECK_LEVEL" => "10"} ],
+          "start" => [ {"interval" => "0", "timeout" => "60"} ],
+          "stop" => [ {"interval" => "0", "timeout" => "40"} ],
         })
       end
 

--- a/templates/corosync.conf.erb
+++ b/templates/corosync.conf.erb
@@ -10,7 +10,7 @@ totem {
   max_messages:                        20
   clear_node_high_bit:                 yes
   rrp_mode:                            <%= @rrp_mode %>
-  secauth:                             <%= @enable_secauth_real %>
+  secauth:                             <%= @enable_secauth_real ? 'on' : 'off' %>
   threads:                             <%= @threads_real %>
 <% [@bind_address_real].flatten.each_index do |i| -%>
   interface {

--- a/templates/corosync.conf.udpu.erb
+++ b/templates/corosync.conf.udpu.erb
@@ -10,7 +10,7 @@ totem {
   max_messages:                        20
   clear_node_high_bit:                 yes
   rrp_mode:                            <%= @rrp_mode %>
-  secauth:                             <%= @enable_secauth_real %>
+  secauth:                             <%= @enable_secauth_real ? 'on' : 'off' %>
   threads:                             <%= @threads_real %>
   transport:                           udpu
   interface {


### PR DESCRIPTION
The cs_commit and cs_shadow types have no default provider. For the other cs_* types the default provider is pcs. This makes pcs the default provider for all types, which silences the "no default provider" warnings.

When cs_shadow resources generate corresponding cs_commit resources, the provider isn't specified and is left to whichever provider Puppet defaults to. This may not be the same as the cs_shadow provider. For example, if cs_shadow is created using the crm provider, the child cs_commit resource will be picked up by pcs, which may result in broken behaviour. This patch passes through the chosen provider to the child resource.

The init.pp contains an exec resource which is invalid, as the resource title is not a valid command and there is no command parameter. The exec resource that is declared on Debian systems in place of this resource enables the daemon by patching /etc/default/corosync, but this is not required on RHEL and is taken care of by the Service['corosync'] resource.

And finally, a couple of typos in the README were fixed :)