### PR TITLE
Added RedHat support

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -205,6 +205,12 @@ class corosync(
     ensure => present,
   }
 
+  if $::osfamily == 'RedHat' {
+    package { 'pcs':
+      ensure => present,
+    }
+  }
+  
   # Template uses:
   # - $unicast_addresses
   # - $multicast_address
@@ -233,12 +239,6 @@ class corosync(
   }
 
   case $::osfamily {
-    'RedHat': {
-      exec { 'enable corosync':
-        require => Package['corosync'],
-        before  => Service['corosync'],
-      }
-    }
     'Debian': {
       exec { 'enable corosync':
         command => 'sed -i s/START=no/START=yes/ /etc/default/corosync',


### PR DESCRIPTION
This commit add's support for RedHat family to the module.

Removed exec as this is not applicable on RedHat systems & added installation of pcs package or there are no providors that work.

This has been tested on CentOS 6.5 x86_64 only.