### PR TITLE
Feature make heartbeat configurable

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -82,20 +82,22 @@
 # Copyright 2012, Puppet Labs, LLC.
 #
 class corosync(
-  $enable_secauth     = 'UNSET',
-  $authkey_source     = 'file',
-  $authkey            = '/etc/puppet/ssl/certs/ca.pem',
-  $threads            = 'UNSET',
-  $port               = 'UNSET',
-  $bind_address       = 'UNSET',
-  $multicast_address  = 'UNSET',
-  $unicast_addresses  = 'UNSET',
-  $force_online       = false,
-  $check_standby      = false,
-  $debug              = false,
-  $rrp_mode           = 'none',
-  $ttl                = false,
-  $packages           = ['corosync', 'pacemaker'],
+  $enable_secauth                                   = 'UNSET',
+  $authkey_source                                   = 'file',
+  $authkey                                          = '/etc/puppet/ssl/certs/ca.pem',
+  $threads                                          = 'UNSET',
+  $port                                             = 'UNSET',
+  $bind_address                                     = 'UNSET',
+  $multicast_address                                = 'UNSET',
+  $unicast_addresses                                = 'UNSET',
+  $force_online                                     = false,
+  $check_standby                                    = false,
+  $debug                                            = false,
+  $rrp_mode                                         = 'none',
+  $ttl                                              = false,
+  $packages                                         = ['corosync', 'pacemaker'],
+  $param_totem_token                                = 3000,
+  $param_totem_token_retransmits_before_loss_const  = 10,
 ) {
 
   # Making it possible to provide data with parameterized class declarations or

--- a/templates/corosync.conf.erb
+++ b/templates/corosync.conf.erb
@@ -2,8 +2,8 @@ compatibility: whitetank
 
 totem {
   version:                             2
-  token:                               3000
-  token_retransmits_before_loss_const: 10
+  token:                               <%= @param_totem_token %>
+  token_retransmits_before_loss_const: <%= @param_totem_token_retransmits_before_loss_const %>
   join:                                60
   consensus:                           3600
   vsftype:                             none

--- a/templates/corosync.conf.udpu.erb
+++ b/templates/corosync.conf.udpu.erb
@@ -2,8 +2,8 @@ compatibility: whitetank
 
 totem {
   version:                             2
-  token:                               3000
-  token_retransmits_before_loss_const: 10
+  token:                               <%= @param_totem_token %>
+  token_retransmits_before_loss_const: <%= @param_totem_token_retransmits_before_loss_const %>
   join:                                60
   consensus:                           3600
   vsftype:                             none


### PR DESCRIPTION
The default heartbeats of 3 seconds are really really short, even too short for VMWare snapshots. 
(See http://linux.die.net/man/5/corosync.conf, as totem is the timeout and not totem * token_retransmits_before_loss_const) 

This change is 100% backward compatible and allows to parametrize the timeouts on the corosync layer. 