### PR TITLE
added cs_clone provider and type (crm only so far)

### DIFF
--- a/lib/puppet/provider/cs_clone/crm.rb
+++ b/lib/puppet/provider/cs_clone/crm.rb
@@ -1,0 +1,162 @@
+require 'pathname'
+require Pathname.new(__FILE__).dirname.dirname.expand_path + 'crmsh'
+
+Puppet::Type.type(:cs_clone).provide(:crm, :parent => Puppet::Provider::Crmsh) do
+  desc 'Provider to add, delete, manipulate primitive clones.'
+
+  # Path to the crm binary for interacting with the cluster configuration.
+  # Decided to just go with relative.
+  commands :crm => 'crm'
+  commands :crm_attribute => 'crm_attribute'
+
+  def self.instances
+
+    block_until_ready
+
+    instances = []
+
+    cmd = [ command(:crm), 'configure', 'show', 'xml' ]
+    if Puppet::PUPPETVERSION.to_f < 3.4
+      raw, status = Puppet::Util::SUIDManager.run_and_capture(cmd)
+    else
+      raw = Puppet::Util::Execution.execute(cmd)
+      status = raw.exitstatus
+    end
+    doc = REXML::Document.new(raw)
+
+    doc.root.elements['configuration'].elements['resources'].each_element('clone') do |e|
+      primitive_id = e.elements['primitive'].attributes['id']
+      items = e.attributes
+
+      clone_instance = {
+        :name            => items['id'],
+        :ensure          => :present,
+        :primitive       => primitive_id,
+        :clone_max       => items['clone-max'],
+        :clone_node_max  => items['clone-node-max'],
+        :notify_clones   => items['notify_clones'],
+        :globally_unique => items['globally-unique'],
+        :ordered         => items['ordered'],
+        :interleave      => items['interleave'],
+
+      }
+      instances << new(clone_instance)
+    end
+    instances
+  end
+
+  # Create just adds our resource to the property_hash and flush will take care
+  # of actually doing the work.
+  def create
+    @property_hash = {
+      :name       => @resource[:name],
+      :ensure     => :present,
+      :primitive       => @resource[:primitive],
+      :clone_max       => @resource[:clone_max],
+      :clone_node_max  => @resource[:clone_node_max],
+      :notify_clones   => @resource[:notify_clones],
+      :globally_unique => @resource[:globally_unique],
+      :ordered         => @resource[:ordered],
+      :interleave      => @resource[:interleave],
+      :cib             => @resource[:cib],
+    }
+  end
+
+  # Unlike create we actually immediately delete the item.
+  def destroy
+    debug('Removing clone')
+    crm('configure', 'delete', @resource[:name])
+    @property_hash.clear
+  end
+  #
+  # Getter that obtains the our service that should have been populated by
+  # prefetch or instances (depends on if your using puppet resource or not).
+  def primitive
+    @property_hash[:primitive]
+  end
+
+  # Getter that obtains the our clone_max that should have been populated by
+  # prefetch or instances (depends on if your using puppet resource or not).
+  def clone_max
+    @property_hash[:clone_max]
+  end
+
+  def clone_node_max
+    @property_hash[:clone_node_max]
+  end
+
+  def notify_clones
+    @property_hash[:notify_clones]
+  end
+
+  def globally_unique
+    @property_hash[:globally_unique]
+  end
+
+  def ordered
+    @property_hash[:ordered]
+  end
+
+  def interleave
+    @property_hash[:interleave]
+  end
+
+  # Our setters.  Setters are used when the
+  # resource already exists so we just update the current value in the property
+  # hash and doing this marks it to be flushed.
+
+  def primitive=(should)
+    @property_hash[:primitive] = should
+  end
+
+  def clone_max=(should)
+    @property_hash[:clone_max] = should
+  end
+
+  def clone_node_max=(should)
+    @property_hash[:clone_node_max] = should
+  end
+
+  def notify_clones=(should)
+    @property_hash[:notify_clones] = should
+  end
+
+  def globally_unique=(should)
+    @property_hash[:globally_unique] = should
+  end
+
+  def ordered=(should)
+    @property_hash[:ordered] = should
+  end
+
+  def interleave=(should)
+    @property_hash[:interleave] = should
+  end
+
+  # Flush is triggered on anything that has been detected as being
+  # modified in the property_hash.  It generates a temporary file with
+  # the updates that need to be made.  The temporary file is then used
+  # as stdin for the crm command.
+  def flush
+    unless @property_hash.empty?
+      updated = "clone "
+      updated << "#{@property_hash[:name]} "
+      updated << "#{@property_hash[:primitive]} "
+
+      meta = ""
+      meta << "clone-max=#{@property_hash[:clone_max]} " if @property_hash[:clone_max]
+      meta << "clone-node-max=#{@property_hash[:clone_node_max]} " if @property_hash[:clone_node_max]
+      meta << "notify=#{@property_hash[:notify_clones]} " if @property_hash[:notify_clones]
+      meta << "globally-unique=#{@property_hash[:globally_unique]} " if @property_hash[:globally_unique]
+      meta << "ordered=#{@property_hash[:ordered]} " if @property_hash[:ordered]
+      meta << "interleave=#{@property_hash[:interleave]}" if @property_hash[:interleave]
+      updated << "meta " << meta if not meta.empty?
+      Tempfile.open('puppet_crm_update') do |tmpfile|
+        tmpfile.write(updated)
+        tmpfile.flush
+        ENV["CIB_shadow"] = @resource[:cib]
+        crm('configure', 'load', 'update', tmpfile.path.to_s)
+      end
+    end
+  end
+end

--- a/lib/puppet/type/cs_clone.rb
+++ b/lib/puppet/type/cs_clone.rb
@@ -1,0 +1,72 @@
+module Puppet
+  newtype(:cs_clone) do
+    @doc = "Type for manipulating corosync/pacemaker resource clone.
+      More information on Corosync/Pacemaker colocation can be found here:
+
+      * http://www.clusterlabs.org/doc/en-US/Pacemaker/1.1/html/Clusters_from_Scratch/_ensuring_resources_run_on_the_same_host.html"
+
+    ensurable
+
+    newparam(:name) do
+      desc "Identifier of the location entry.  This value needs to be unique
+        across the entire Corosync/Pacemaker configuration since it doesn't have
+        the concept of name spaces per type."
+
+      isnamevar
+    end
+
+    newproperty(:primitive) do
+      desc "The corosync resource primitive to be cloned.  "
+    end
+
+    newproperty(:clone_max) do
+      desc "How many copies of the resource to start.
+        Defaults to the number of nodes in the cluster."
+    end
+    newproperty(:clone_node_max) do
+      desc "How many copies of the resource can be started on a single node.
+      Defaults to 1."
+    end
+
+    newproperty(:notify_clones) do
+      desc "When stopping or starting a copy of the clone, tell all the other copies beforehand
+        and when the action was successful.
+        Allowed values: true, false"
+    end
+
+    newproperty(:globally_unique) do
+      desc "Does each copy of the clone perform a different function?
+        Allowed values: true, false"
+    end
+
+    newproperty(:ordered) do
+      desc "Should the copies be started in series (instead of in parallel). Allowed values: true, false"
+    end
+
+    newproperty(:interleave) do
+      desc "Changes the behavior of ordering constraints (between clones/masters) so that instances can start/stop
+        as soon as their peer instance has (rather than waiting for every instance of the other clone has).
+        Allowed values: true, false"
+    end
+
+    newparam(:cib) do
+      desc "Corosync applies its configuration immediately. Using a CIB allows
+        you to group multiple primitives and relationships to be applied at
+        once. This can be necessary to insert complex configurations into
+        Corosync correctly.
+
+        This paramater sets the CIB this colocation should be created in. A
+        cs_shadow resource with a title of the same name as this value should
+        also be added to your manifest."
+    end
+
+    autorequire(:cs_shadow) do
+      [ @parameters[:cib] ]
+    end
+
+    autorequire(:service) do
+      [ 'corosync' ]
+    end
+
+  end
+end


### PR DESCRIPTION
Hi,

I've added a cs_clone type and provider.  It only supports crm, not pcs yet.  The code was shamelessly stolen from other resources in this module.  There are no tests for the cs_clone type and it hasn't been tested robustly, but it works for me so far on a live Pacemaker cluster.