### PR TITLE
removed colocation sort, order is important

### DIFF
--- a/lib/puppet/provider/cs_colocation/crm.rb
+++ b/lib/puppet/provider/cs_colocation/crm.rb
@@ -53,7 +53,7 @@ Puppet::Type.type(:cs_colocation).provide(:crm, :parent => Puppet::Provider::Crm
       colocation_instance = {
         :name       => items['id'],
         :ensure     => :present,
-        :primitives => rscs.sort,
+        :primitives => rscs,
         :score      => items['score'],
         :provider   => self.name
       }
@@ -98,7 +98,7 @@ Puppet::Type.type(:cs_colocation).provide(:crm, :parent => Puppet::Provider::Crm
   # resource already exists so we just update the current value in the property
   # hash and doing this marks it to be flushed.
   def primitives=(should)
-    @property_hash[:primitives] = should.sort
+    @property_hash[:primitives] = should
   end
 
   def score=(should)

--- a/lib/puppet/provider/cs_colocation/pcs.rb
+++ b/lib/puppet/provider/cs_colocation/pcs.rb
@@ -43,7 +43,7 @@ Puppet::Type.type(:cs_colocation).provide(:pcs, :parent => Puppet::Provider::Pac
       colocation_instance = {
         :name       => items['id'],
         :ensure     => :present,
-        :primitives => [rsc, with_rsc].sort,
+        :primitives => [rsc, with_rsc],
         :score      => items['score'],
         :provider   => self.name,
         :new        => false
@@ -91,7 +91,7 @@ Puppet::Type.type(:cs_colocation).provide(:pcs, :parent => Puppet::Provider::Pac
   # resource already exists so we just update the current value in the property
   # hash and doing this marks it to be flushed.
   def primitives=(should)
-    @property_hash[:primitives] = should.sort
+    @property_hash[:primitives] = should
   end
 
   def score=(should)

--- a/lib/puppet/type/cs_colocation.rb
+++ b/lib/puppet/type/cs_colocation.rb
@@ -33,7 +33,7 @@ module Puppet
         super
         if value.is_a? Array
           raise Puppet::Error, "Puppet::Type::Cs_Colocation: The primitives property must be a two value array." unless value.size >= 2
-          @should.sort!
+          @should
         else
           raise Puppet::Error, "Puppet::Type::Cs_Colocation: The primitives property must be a two value array."
           @should


### PR DESCRIPTION
Example:

   a
  / \
 b   c

colocation a b
colocation a c

this tells resource a to colocate with b and c, if b and c are on diffrent nodes,
a will randomly choose a node,
b and c will not care about colocation

colocation b a
colocation c a

this tells the resources b and c to colocate with a,
a will not care about colocation, but b and c will go to the node where resource a is.

The result is completly different depending on the order.