### PR TITLE
Fix creation of primitives with PCS

### DIFF
--- a/lib/puppet/provider/cs_primitive/pcs.rb
+++ b/lib/puppet/provider/cs_primitive/pcs.rb
@@ -240,7 +240,7 @@ Puppet::Type.type(:cs_primitive).provide(:pcs, :parent => Puppet::Provider::Pace
       unless @property_hash[:parameters].empty?
         parameters = []
         @property_hash[:parameters].each_pair do |k,v|
-          parameters << "'#{k}=#{v}'"
+          parameters << "#{k}=#{v}"
         end
       end
       unless @property_hash[:utilization].empty?


### PR DESCRIPTION
Commit 755f3c9 breaks pcs support to
create primitives. This is because the "crm" way to update the cluster
is by flattening an array where for pcs we call the command with
arguments as an array.

Commit 755f3c9 did then break pcs. This
commit fixes that by reverting the changes in pcs.rb.