### PR TITLE
Order IS relavent for colocation's primitives.

### DIFF
--- a/lib/puppet/type/cs_colocation.rb
+++ b/lib/puppet/type/cs_colocation.rb
@@ -22,7 +22,7 @@ module Puppet
 
     newproperty(:primitives, :array_matching => :all) do
       desc "Two Corosync primitives to be grouped together.  Colocation groups
-        come in twos and order is irrelavent.  Property will raise an error if
+        come in twos and order is absolutely relavent.  Property will raise an error if
         you do not provide a two value array."
 
       # Have to redefine should= here so we can sort the array that is given to
@@ -33,7 +33,7 @@ module Puppet
         super
         if value.is_a? Array
           raise Puppet::Error, "Puppet::Type::Cs_Colocation: The primitives property must be a two value array." unless value.size >= 2
-          @should.sort!
+          @should
         else
           raise Puppet::Error, "Puppet::Type::Cs_Colocation: The primitives property must be a two value array."
           @should


### PR DESCRIPTION
Base stated that order for primitives in a colocation is irrelavent, but pacemaker's documentation states the opposite (http://clusterlabs.org/doc/en-US/Pacemaker/1.1/html/Pacemaker_Explained/s-resource-colocation.html chapter 6.4).
One obvious way to show this is to colocate a primitive (IPFailover for example) with a cloned primitive running everywhere (let's take an Apache).
If we have primitives['IPFailover','Apache'], then IPFailover will run only where Apache runs (that's everywhere since Apache is cloned on every nodes).
If we have primitives['Apache','IPFailover'], then Apache will run only where IPFailover runs, and thus, only one apache will run at time (not desired behaviour !).