### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,35 +1,17 @@
+---
 language: ruby
-bundler_args: --without development
-before_install:
-  - gem update --system 2.1.11
-  - gem --version
-script: "bundle exec rake spec SPEC_OPTS='--format documentation'"
-rvm:
-  - 1.8.7
-  - 1.9.3
-  - 2.0.0
-env:
-  - PUPPET_GEM_VERSION="~> 2.7.0"
-  - PUPPET_GEM_VERSION="~> 3.0.0"
-  - PUPPET_GEM_VERSION="~> 3.1.0"
-  - PUPPET_GEM_VERSION="~> 3.2.0"
-  - PUPPET_GEM_VERSION="~> 3.3.0"
-  - PUPPET_GEM_VERSION="~> 3.4.0"
+bundler_args: --without system_tests
+script: "bundle exec rake validate && bundle exec rake lint && bundle exec rake spec SPEC_OPTS='--format documentation'"
 matrix:
-  exclude:
-    - rvm: 1.9.3
-      env: PUPPET_GEM_VERSION="~> 2.7.0"
-    - rvm: 2.0.0
-      env: PUPPET_GEM_VERSION="~> 2.7.0"
-    - rvm: 2.0.0
-      env: PUPPET_GEM_VERSION="~> 3.0.0"
-    - rvm: 2.0.0
-      env: PUPPET_GEM_VERSION="~> 3.1.0"
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 3.2.0"
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 3.3.0"
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 3.4.0"
+  fast_finish: true
+  include:
+  - rvm: 1.8.7
+    env: PUPPET_GEM_VERSION="~> 2.7.0" FACTER_GEM_VERSION="~> 1.6.0"
+  - rvm: 1.8.7
+    env: PUPPET_GEM_VERSION="~> 2.7.0" FACTER_GEM_VERSION="~> 1.7.0"
+  - rvm: 1.9.3
+    env: PUPPET_GEM_VERSION="~> 3.0"
+  - rvm: 2.0.0
+    env: PUPPET_GEM_VERSION="~> 3.0"
 notifications:
   email: false


### PR DESCRIPTION
This commit brings .travis.yml up to date with the other puppetlabs
modules. It will cause tests to run on Puppet 2.7 and the latest 3.x
instead of every minor 3 version. This will avoid strange failures
on older puppet versions.