### PR TITLE
Add a force option to cs_primitive

### DIFF
--- a/lib/puppet/provider/cs_primitive/crm.rb
+++ b/lib/puppet/provider/cs_primitive/crm.rb
@@ -260,11 +260,10 @@ Puppet::Type.type(:cs_primitive).provide(:crm, :parent => Puppet::Provider::Crms
         tmpfile.flush
         ENV['CIB_shadow'] = @resource[:cib]
         if @property_hash[:force] == :true
-            crm_force = '-F'
+          crm('-F', 'configure', 'load', 'update', tmpfile.path.to_s)   
         else
-            crm_force = ''
+          crm('configure', 'load', 'update', tmpfile.path.to_s)      
         end
-        crm(crm_force, 'configure', 'load', 'update', tmpfile.path.to_s)
       end
     end
   end

--- a/lib/puppet/provider/cs_primitive/pcs.rb
+++ b/lib/puppet/provider/cs_primitive/pcs.rb
@@ -114,6 +114,7 @@ Puppet::Type.type(:cs_primitive).provide(:pcs, :parent => Puppet::Provider::Pace
     @property_hash[:metadata] = @resource[:metadata] if ! @resource[:metadata].nil?
     @property_hash[:ms_metadata] = @resource[:ms_metadata] if ! @resource[:ms_metadata].nil?
     @property_hash[:cib] = @resource[:cib] if ! @resource[:cib].nil?
+    @property_hash[:force] = @resource[:force] if ! @resource[:force].nil?
   end
 
   # Unlike create we actually immediately delete the item.
@@ -162,6 +163,10 @@ Puppet::Type.type(:cs_primitive).provide(:pcs, :parent => Puppet::Provider::Pace
     @property_hash[:promotable]
   end
 
+  def force
+    @property_hash[:force]
+  end
+
   # Our setters for parameters and operations.  Setters are used when the
   # resource already exists so we just update the current value in the
   # property_hash and doing this marks it to be flushed.
@@ -204,6 +209,10 @@ Puppet::Type.type(:cs_primitive).provide(:pcs, :parent => Puppet::Provider::Pace
       @property_hash[:promotable] = should
       pcs('resource', 'delete', "ms_#{@resource[:name]}")
     end
+  end
+
+  def force=(should)
+    @property_hash[:force] = should
   end
 
   # Flush is triggered on anything that has been detected as being
@@ -277,6 +286,7 @@ Puppet::Type.type(:cs_primitive).provide(:pcs, :parent => Puppet::Provider::Pace
         cmd += operations unless operations.nil?
         cmd += utilization unless utilization.nil?
         cmd += metadatas unless metadatas.nil?
+        cmd << '--force' if @property_hash[:force] == :true
         raw, status = Puppet::Provider::Pacemaker::run_pcs_command(cmd)
         # if we are using a master/slave resource, prepend ms_ before its name
         # and declare it as a master/slave resource
@@ -312,6 +322,7 @@ Puppet::Type.type(:cs_primitive).provide(:pcs, :parent => Puppet::Provider::Pace
         cmd += operations unless operations.nil?
         cmd += utilization unless utilization.nil?
         cmd += metadatas unless metadatas.nil?
+        cmd << '--force' if @property_hash[:force] == :true
         raw, status = Puppet::Provider::Pacemaker::run_pcs_command(cmd)
         if @property_hash[:promotable] == :true
           cmd = [ command(:pcs), 'resource', 'update', "ms_#{@property_hash[:name]}", "#{@property_hash[:name]}" ]

--- a/lib/puppet/type/cs_primitive.rb
+++ b/lib/puppet/type/cs_primitive.rb
@@ -157,6 +157,14 @@ module Puppet
         defaultto :false
     end
 
+    newproperty(:force) do
+      desc "Forces the primitive creation, even if it should fail."
+
+        newvalues(:true, :false)
+
+        defaultto :false
+    end
+
     autorequire(:cs_shadow) do
       autos = []
       if @parameters[:cib]

--- a/spec/unit/puppet/provider/cs_primitive_crm_spec.rb
+++ b/spec/unit/puppet/provider/cs_primitive_crm_spec.rb
@@ -183,4 +183,39 @@ describe Puppet::Type.type(:cs_primitive).provider(:crm) do
       instance.flush
     end
   end
+
+
+  context 'when forcing creation' do
+    let :resource do
+      Puppet::Type.type(:cs_primitive).new(
+        :name => 'testResource',
+        :provider => :crm,
+        :primitive_class => 'ocf',
+        :provided_by => 'heartbeat',
+        :primitive_type => 'IPaddr2',
+        :force => true)
+    end
+
+    let :instance do
+      instance = described_class.new(resource)
+      instance.create
+      instance
+    end
+
+    def expect_update(pattern)
+      instance.expects(:crm).with { |*args|
+        if args.slice(0..3) == ['-F', 'configure', 'load', 'update']
+          expect(File.read(args[4])).to match(pattern)
+          true
+        else
+          false
+        end
+      }
+    end
+
+    it 'can flush without changes' do
+      expect_update(//)
+      instance.flush
+    end
+  end
 end

--- a/spec/unit/puppet/provider/cs_primitive_pcs_spec.rb
+++ b/spec/unit/puppet/provider/cs_primitive_pcs_spec.rb
@@ -223,6 +223,43 @@ describe Puppet::Type.type(:cs_primitive).provider(:pcs) do
       expect_update(/resource (create|delete|op remove) example_vip/)
       vip_instance.flush
     end
+  end
 
+  context 'when forcing' do
+     def expect_update(pattern)
+      if Puppet::PUPPETVERSION.to_f < 3.4
+        Puppet::Util::SUIDManager.expects(:run_and_capture).with { |*args|
+          cmdline=args[0].join(" ")
+          expect(cmdline).to match(pattern)
+          true
+        }.at_least_once.returns(['', 0])
+      else
+        Puppet::Util::Execution.expects(:execute).with{ |*args|
+          cmdline=args[0].join(" ")
+          expect(cmdline).to match(pattern)
+          true
+        }.at_least_once.returns(
+          Puppet::Util::Execution::ProcessOutput.new('', 0)
+        )
+      end
+    end
+
+    let :resource do
+      Puppet::Type.type(:cs_primitive).new(
+        :name => 'testResource',
+        :provider => :crm,
+        :primitive_class => 'ocf',
+        :provided_by => 'heartbeat',
+        :primitive_type => 'IPaddr2',
+        :force => true)
+    end
+
+    it 'creates with --force' do
+      instance = described_class.new(resource)
+      instance.create
+      instance
+      instance.flush
+      expect_update(/--force/)
+    end
   end
 end

--- a/spec/unit/puppet/provider/cs_primitive_pcs_spec.rb
+++ b/spec/unit/puppet/provider/cs_primitive_pcs_spec.rb
@@ -155,7 +155,7 @@ describe Puppet::Type.type(:cs_primitive).provider(:pcs) do
     let :resource do
       Puppet::Type.type(:cs_primitive).new(
         :name => 'testResource',
-        :provider => :crm,
+        :provider => :pcs,
         :primitive_class => 'ocf',
         :provided_by => 'heartbeat',
         :primitive_type => 'IPaddr2')
@@ -225,41 +225,50 @@ describe Puppet::Type.type(:cs_primitive).provider(:pcs) do
     end
   end
 
-  context 'when forcing' do
-     def expect_update(pattern)
-      if Puppet::PUPPETVERSION.to_f < 3.4
-        Puppet::Util::SUIDManager.expects(:run_and_capture).with { |*args|
-          cmdline=args[0].join(" ")
-          expect(cmdline).to match(pattern)
-          true
-        }.at_least_once.returns(['', 0])
-      else
-        Puppet::Util::Execution.expects(:execute).with{ |*args|
-          cmdline=args[0].join(" ")
-          expect(cmdline).to match(pattern)
-          true
-        }.at_least_once.returns(
-          Puppet::Util::Execution::ProcessOutput.new('', 0)
-        )
-      end
-    end
-
+  context 'when forcing creation' do
     let :resource do
       Puppet::Type.type(:cs_primitive).new(
-        :name => 'testResource',
-        :provider => :crm,
+        :name => 'testForce',
+        :provider => :pcs,
         :primitive_class => 'ocf',
         :provided_by => 'heartbeat',
         :primitive_type => 'IPaddr2',
         :force => true)
     end
 
-    it 'creates with --force' do
+    let :instance do
       instance = described_class.new(resource)
       instance.create
       instance
+    end
+
+    def expect_force
+      if Puppet::PUPPETVERSION.to_f < 3.4
+        Puppet::Util::SUIDManager.expects(:run_and_capture).with { |*args|
+          cmdline=args[0].join(" ")
+          if cmdline.match(/^pcs resource create testForce/)
+            cmdline.match(/--force$/)
+          else
+            true
+          end
+        }.at_least_once.returns(['', 0])
+      else
+        Puppet::Util::Execution.expects(:execute).with{ |*args|
+          cmdline=args[0].join(" ")
+          if cmdline.match(/^pcs resource create testForce/)
+            cmdline.match(/--force$/)
+          else
+            true
+          end
+        }.at_least_once.returns(
+          Puppet::Util::Execution::ProcessOutput.new('', 0)
+        )
+      end
+    end
+
+    it 'can flush without changes' do
+      expect_force
       instance.flush
-      expect_update(/--force/)
     end
   end
 end

--- a/spec/unit/puppet/type/cs_primitive_spec.rb
+++ b/spec/unit/puppet/type/cs_primitive_spec.rb
@@ -69,5 +69,23 @@ describe Puppet::Type.type(:cs_primitive) do
         ) }.to raise_error Puppet::Error, /(true|false)/
       end
     end
+
+    it "should validate that the force attribute can be true/false" do
+      [true, false].each do |value|
+        expect(subject.new(
+          :name       => "mock_primitive",
+          :force => value
+        )[:force]).to eq(value.to_s.to_sym)
+      end
+    end
+
+    it "should validate that the force attribute cannot be other values" do
+      ["fail", 42].each do |value|
+        expect { subject.new(
+          :name       => "mock_primitive",
+          :force => value
+        ) }.to raise_error Puppet::Error, /(true|false)/
+      end
+    end
   end
 end


### PR DESCRIPTION
Adding the option to force creation of cs_primitive, even if the command should fail. This is useful for example when creating a primitive using systemd scripts, but the systemd script is not yet there because the package was not installed. 