### PR TITLE
Add a force option to cs_primitive

### DIFF
--- a/lib/puppet/provider/cs_primitive/crm.rb
+++ b/lib/puppet/provider/cs_primitive/crm.rb
@@ -118,6 +118,7 @@ Puppet::Type.type(:cs_primitive).provide(:crm, :parent => Puppet::Provider::Crms
     @property_hash[:metadata] = @resource[:metadata] if ! @resource[:metadata].nil?
     @property_hash[:ms_metadata] = @resource[:ms_metadata] if ! @resource[:ms_metadata].nil?
     @property_hash[:cib] = @resource[:cib] if ! @resource[:cib].nil?
+    @property_hash[:force] = @resource[:force] if ! @resource[:force].nil?
   end
 
   # Unlike create we actually immediately delete the item.  Corosync forces us
@@ -157,6 +158,10 @@ Puppet::Type.type(:cs_primitive).provide(:crm, :parent => Puppet::Provider::Crms
     @property_hash[:promotable]
   end
 
+  def force
+    @property_hash[:force]
+  end
+
   # Our setters for parameters and operations.  Setters are used when the
   # resource already exists so we just update the current value in the
   # property_hash and doing this marks it to be flushed.
@@ -189,6 +194,10 @@ Puppet::Type.type(:cs_primitive).provide(:crm, :parent => Puppet::Provider::Crms
       crm('resource', 'stop', "ms_#{@resource[:name]}")
       crm('configure', 'delete', "ms_#{@resource[:name]}")
     end
+  end
+
+  def force=(should)
+    @property_hash[:force] = should
   end
 
   # Flush is triggered on anything that has been detected as being
@@ -250,7 +259,11 @@ Puppet::Type.type(:cs_primitive).provide(:crm, :parent => Puppet::Provider::Crms
         tmpfile.write(updated)
         tmpfile.flush
         ENV['CIB_shadow'] = @resource[:cib]
-        crm('configure', 'load', 'update', tmpfile.path.to_s)
+        if @property_hash[:force] == :true
+          crm('-F', 'configure', 'load', 'update', tmpfile.path.to_s)   
+        else
+          crm('configure', 'load', 'update', tmpfile.path.to_s)      
+        end
       end
     end
   end

--- a/lib/puppet/provider/cs_primitive/pcs.rb
+++ b/lib/puppet/provider/cs_primitive/pcs.rb
@@ -114,6 +114,7 @@ Puppet::Type.type(:cs_primitive).provide(:pcs, :parent => Puppet::Provider::Pace
     @property_hash[:metadata] = @resource[:metadata] if ! @resource[:metadata].nil?
     @property_hash[:ms_metadata] = @resource[:ms_metadata] if ! @resource[:ms_metadata].nil?
     @property_hash[:cib] = @resource[:cib] if ! @resource[:cib].nil?
+    @property_hash[:force] = @resource[:force] if ! @resource[:force].nil?
   end
 
   # Unlike create we actually immediately delete the item.
@@ -162,6 +163,10 @@ Puppet::Type.type(:cs_primitive).provide(:pcs, :parent => Puppet::Provider::Pace
     @property_hash[:promotable]
   end
 
+  def force
+    @property_hash[:force]
+  end
+
   # Our setters for parameters and operations.  Setters are used when the
   # resource already exists so we just update the current value in the
   # property_hash and doing this marks it to be flushed.
@@ -204,6 +209,10 @@ Puppet::Type.type(:cs_primitive).provide(:pcs, :parent => Puppet::Provider::Pace
       @property_hash[:promotable] = should
       pcs('resource', 'delete', "ms_#{@resource[:name]}")
     end
+  end
+
+  def force=(should)
+    @property_hash[:force] = should
   end
 
   # Flush is triggered on anything that has been detected as being
@@ -277,6 +286,7 @@ Puppet::Type.type(:cs_primitive).provide(:pcs, :parent => Puppet::Provider::Pace
         cmd += operations unless operations.nil?
         cmd += utilization unless utilization.nil?
         cmd += metadatas unless metadatas.nil?
+        cmd << '--force' if @property_hash[:force] == :true
         raw, status = Puppet::Provider::Pacemaker::run_pcs_command(cmd)
         # if we are using a master/slave resource, prepend ms_ before its name
         # and declare it as a master/slave resource
@@ -312,6 +322,7 @@ Puppet::Type.type(:cs_primitive).provide(:pcs, :parent => Puppet::Provider::Pace
         cmd += operations unless operations.nil?
         cmd += utilization unless utilization.nil?
         cmd += metadatas unless metadatas.nil?
+        cmd << '--force' if @property_hash[:force] == :true
         raw, status = Puppet::Provider::Pacemaker::run_pcs_command(cmd)
         if @property_hash[:promotable] == :true
           cmd = [ command(:pcs), 'resource', 'update', "ms_#{@property_hash[:name]}", "#{@property_hash[:name]}" ]

--- a/lib/puppet/type/cs_primitive.rb
+++ b/lib/puppet/type/cs_primitive.rb
@@ -64,6 +64,14 @@ module Puppet
         also be added to your manifest."
     end
 
+    newparam(:force) do
+      desc "Forces the primitive creation."
+
+        newvalues(:true, :false)
+
+        defaultto :false
+    end
+
     # Our parameters and operations properties must be hashes.
     newproperty(:parameters) do
       desc "A hash of params for the primitive.  Parameters in a primitive are

--- a/spec/unit/puppet/provider/cs_primitive_crm_spec.rb
+++ b/spec/unit/puppet/provider/cs_primitive_crm_spec.rb
@@ -183,4 +183,39 @@ describe Puppet::Type.type(:cs_primitive).provider(:crm) do
       instance.flush
     end
   end
+
+
+  context 'when forcing creation' do
+    let :resource do
+      Puppet::Type.type(:cs_primitive).new(
+        :name => 'testResource',
+        :provider => :crm,
+        :primitive_class => 'ocf',
+        :provided_by => 'heartbeat',
+        :primitive_type => 'IPaddr2',
+        :force => true)
+    end
+
+    let :instance do
+      instance = described_class.new(resource)
+      instance.create
+      instance
+    end
+
+    def expect_update(pattern)
+      instance.expects(:crm).with { |*args|
+        if args.slice(0..3) == ['-F', 'configure', 'load', 'update']
+          expect(File.read(args[4])).to match(pattern)
+          true
+        else
+          false
+        end
+      }
+    end
+
+    it 'can flush without changes' do
+      expect_update(//)
+      instance.flush
+    end
+  end
 end

--- a/spec/unit/puppet/type/cs_primitive_spec.rb
+++ b/spec/unit/puppet/type/cs_primitive_spec.rb
@@ -69,5 +69,23 @@ describe Puppet::Type.type(:cs_primitive) do
         ) }.to raise_error Puppet::Error, /(true|false)/
       end
     end
+
+    it "should validate that the force attribute can be true/false" do
+      [true, false].each do |value|
+        expect(subject.new(
+          :name       => "mock_primitive",
+          :force => value
+        )[:force]).to eq(value.to_s.to_sym)
+      end
+    end
+
+    it "should validate that the force attribute cannot be other values" do
+      ["fail", 42].each do |value|
+        expect { subject.new(
+          :name       => "mock_primitive",
+          :force => value
+        ) }.to raise_error Puppet::Error, /(true|false)/
+      end
+    end
   end
 end


### PR DESCRIPTION
Adding the option to force creation of cs_primitive, even if the
command should fail. This is useful for example when creating a
primitive using systemd scripts, but the systemd script is not yet
there because the package was not installed.