### PR TITLE
Add cs_clone provider and type (complete)

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,21 @@ cs_order { 'vip_before_service':
 }
 ```
 
+Configuring cloned resources
+----------------------------
+
+Cloned resources should be active on multiple hosts at the same time. You can
+clone any existing resource provided the resource agent supports it.
+
+```puppet
+cs_clone { 'nginx_service-clone' :
+  ensure    => present,
+  primitive => 'nginx_service',
+  clone_max => 3,
+  require   => Cs_primitive['nginx_service'],
+}
+```
+
 Corosync Properties
 ------------------
 A few gloabal settings can be changed with the "cs_property" section.

--- a/lib/puppet/provider/cs_clone/crm.rb
+++ b/lib/puppet/provider/cs_clone/crm.rb
@@ -1,0 +1,197 @@
+require 'pathname'
+require Pathname.new(__FILE__).dirname.dirname.expand_path + 'crmsh'
+
+Puppet::Type.type(:cs_clone).provide(:crm, :parent => Puppet::Provider::Crmsh) do
+  desc 'Provider to add, delete, manipulate primitive clones.'
+
+  # Path to the crm binary for interacting with the cluster configuration.
+  # Decided to just go with relative.
+  commands :crm => 'crm'
+  commands :crm_attribute => 'crm_attribute'
+
+  # given an XML element containing some <nvpair>s, return a hash. Return an
+  # empty hash if `e` is nil.
+  def self.nvpairs_to_hash(e)
+    return {} if e.nil?
+
+    hash = {}
+    e.each_element do |i|
+      hash[(i.attributes['name'])] = i.attributes['value'].strip
+    end
+
+    hash
+  end
+
+  def self.instances
+
+    block_until_ready
+
+    instances = []
+
+    cmd = [ command(:crm), 'configure', 'show', 'xml' ]
+    if Puppet::PUPPETVERSION.to_f < 3.4
+      raw, status = Puppet::Util::SUIDManager.run_and_capture(cmd)
+    else
+      raw = Puppet::Util::Execution.execute(cmd)
+      status = raw.exitstatus
+    end
+    doc = REXML::Document.new(raw)
+
+    doc.root.elements['configuration'].elements['resources'].each_element('clone') do |e|
+      primitive_id = e.elements['primitive'].attributes['id']
+      items = nvpairs_to_hash(e.elements['meta_attributes'])
+
+      clone_instance = {
+        :name            => e.attributes['id'],
+        :ensure          => :present,
+        :primitive       => primitive_id,
+        :clone_max       => items['clone-max'],
+        :clone_node_max  => items['clone-node-max'],
+        :notify_clones   => items['notify'],
+        :globally_unique => items['globally-unique'],
+        :ordered         => items['ordered'],
+        :interleave      => items['interleave'],
+        :existing_resource => :true,
+      }
+      instances << new(clone_instance)
+    end
+    instances
+  end
+
+  # Create just adds our resource to the property_hash and flush will take care
+  # of actually doing the work.
+  def create
+    @property_hash = {
+      :name       => @resource[:name],
+      :ensure     => :present,
+      :primitive       => @resource[:primitive],
+      :clone_max       => @resource[:clone_max],
+      :clone_node_max  => @resource[:clone_node_max],
+      :notify_clones   => @resource[:notify_clones],
+      :globally_unique => @resource[:globally_unique],
+      :ordered         => @resource[:ordered],
+      :interleave      => @resource[:interleave],
+      :cib             => @resource[:cib],
+      :existing_resource => :false,
+    }
+  end
+
+  # Unlike create we actually immediately delete the item.
+  def destroy
+    debug('Removing clone')
+    crm('configure', 'delete', @resource[:name])
+    @property_hash.clear
+  end
+  #
+  # Getter that obtains the our service that should have been populated by
+  # prefetch or instances (depends on if your using puppet resource or not).
+  def primitive
+    @property_hash[:primitive]
+  end
+
+  # Getter that obtains the our clone_max that should have been populated by
+  # prefetch or instances (depends on if your using puppet resource or not).
+  def clone_max
+    @property_hash[:clone_max]
+  end
+
+  def clone_node_max
+    @property_hash[:clone_node_max]
+  end
+
+  def notify_clones
+    @property_hash[:notify_clones]
+  end
+
+  def globally_unique
+    @property_hash[:globally_unique]
+  end
+
+  def ordered
+    @property_hash[:ordered]
+  end
+
+  def interleave
+    @property_hash[:interleave]
+  end
+
+  # Our setters.  Setters are used when the
+  # resource already exists so we just update the current value in the property
+  # hash and doing this marks it to be flushed.
+
+  def primitive=(should)
+    @property_hash[:primitive] = should
+  end
+
+  def clone_max=(should)
+    @property_hash[:clone_max] = should
+  end
+
+  def clone_node_max=(should)
+    @property_hash[:clone_node_max] = should
+  end
+
+  def notify_clones=(should)
+    @property_hash[:notify_clones] = should
+  end
+
+  def globally_unique=(should)
+    @property_hash[:globally_unique] = should
+  end
+
+  def ordered=(should)
+    @property_hash[:ordered] = should
+  end
+
+  def interleave=(should)
+    @property_hash[:interleave] = should
+  end
+
+  # Flush is triggered on anything that has been detected as being
+  # modified in the property_hash.  It generates a temporary file with
+  # the updates that need to be made.  The temporary file is then used
+  # as stdin for the crm command.
+  def flush
+    unless @property_hash.empty?
+      if @property_hash[:existing_resource] == :false
+        debug ('Creating clone resource')
+        updated = "clone "
+        updated << "#{@property_hash[:name]} "
+        updated << "#{@property_hash[:primitive]} "
+        meta = ""
+        meta << "clone-max=#{@property_hash[:clone_max]} " if @property_hash[:clone_max]
+        meta << "clone-node-max=#{@property_hash[:clone_node_max]} " if @property_hash[:clone_node_max]
+        meta << "notify=#{@property_hash[:notify_clones]} " if @property_hash[:notify_clones]
+        meta << "globally-unique=#{@property_hash[:globally_unique]} " if @property_hash[:globally_unique]
+        meta << "ordered=#{@property_hash[:ordered]} " if @property_hash[:ordered]
+        meta << "interleave=#{@property_hash[:interleave]}" if @property_hash[:interleave]
+        updated << "meta " << meta if not meta.empty?
+        Tempfile.open('puppet_crm_update') do |tmpfile|
+          tmpfile.write(updated)
+          tmpfile.flush
+          ENV["CIB_shadow"] = @resource[:cib]
+          crm('configure', 'load', 'update', tmpfile.path.to_s)
+        end
+      else
+        debug ('Updating clone resource')
+        updated = "resource meta "
+        updated << "#{@property_hash[:name]} "
+        meta = "set "
+        meta << "clone-max=#{@property_hash[:clone_max]} " if @property_hash[:clone_max]
+        meta << "clone-node-max=#{@property_hash[:clone_node_max]} " if @property_hash[:clone_node_max]
+        meta << "notify=#{@property_hash[:notify_clones]} " if @property_hash[:notify_clones]
+        meta << "globally-unique=#{@property_hash[:globally_unique]} " if @property_hash[:globally_unique]
+        meta << "ordered=#{@property_hash[:ordered]} " if @property_hash[:ordered]
+        meta << "interleave=#{@property_hash[:interleave]}" if @property_hash[:interleave]
+        updated << meta if not meta.empty?
+        Tempfile.open('puppet_crm_update') do |tmpfile|
+          tmpfile.write(updated)
+          tmpfile.flush
+          ENV["CIB_shadow"] = @resource[:cib]
+          crm('configure', 'load', 'update', tmpfile.path.to_s)
+        end
+      end
+    end
+  end
+end
+

--- a/lib/puppet/provider/cs_clone/pcs.rb
+++ b/lib/puppet/provider/cs_clone/pcs.rb
@@ -1,0 +1,182 @@
+require 'pathname'
+require Pathname.new(__FILE__).dirname.dirname.expand_path + 'pacemaker'
+
+Puppet::Type.type(:cs_clone).provide(:pcs, :parent => Puppet::Provider::Pacemaker) do
+  desc 'Provider to add, delete, manipulate primitive clones.'
+
+  commands :pcs => 'pcs'
+
+  defaultfor :operatingsystem => [:fedora, :centos, :redhat]
+
+  # given an XML element containing some <nvpair>s, return a hash. Return an
+  # empty hash if `e` is nil.
+  def self.nvpairs_to_hash(e)
+    return {} if e.nil?
+
+    hash = {}
+    e.each_element do |i|
+      hash[(i.attributes['name'])] = i.attributes['value'].strip
+    end
+
+    hash
+  end
+
+  def self.instances
+
+    block_until_ready
+
+    instances = []
+
+    cmd = [ command(:pcs), 'cluster', 'cib' ]
+    raw, status = run_pcs_command(cmd)
+    doc = REXML::Document.new(raw)
+
+    doc.root.elements['configuration'].elements['resources'].each_element('clone') do |e|
+      primitive_id = e.elements['primitive'].attributes['id']
+      items = nvpairs_to_hash(e.elements['meta_attributes'])
+
+      clone_instance = {
+        :name              => e.attributes['id'],
+        :ensure            => :present,
+        :primitive         => primitive_id,
+        :clone_max         => items['clone-max'],
+        :clone_node_max    => items['clone-node-max'],
+        :notify_clones     => items['notify'],
+        :globally_unique   => items['globally-unique'],
+        :ordered           => items['ordered'],
+        :interleave        => items['interleave'],
+        :existing_resource => :true,
+      }
+      instances << new(clone_instance)
+    end
+    instances
+  end
+
+  # Create just adds our resource to the property_hash and flush will take care
+  # of actually doing the work.
+  def create
+    @property_hash = {
+      :name              => @resource[:primitive]+'-clone',
+      :ensure            => :present,
+      :primitive         => @resource[:primitive],
+      :clone_max         => @resource[:clone_max],
+      :clone_node_max    => @resource[:clone_node_max],
+      :notify_clones     => @resource[:notify_clones],
+      :globally_unique   => @resource[:globally_unique],
+      :ordered           => @resource[:ordered],
+      :interleave        => @resource[:interleave],
+      :cib               => @resource[:cib],
+      :existing_resource => :false,
+    }
+  end
+
+  # Unlike create we actually immediately delete the item.
+  def destroy
+    debug('Removing clone')
+    Puppet::Provider::Pacemaker::run_pcs_command([command(:pcs), 'resource', 'unclone', @resource[:name]])
+    @property_hash.clear
+  end
+  #
+  # Getter that obtains the our service that should have been populated by
+  # prefetch or instances (depends on if your using puppet resource or not).
+  def primitive
+    @property_hash[:primitive]
+  end
+
+  # Getter that obtains the our clone_max that should have been populated by
+  # prefetch or instances (depends on if your using puppet resource or not).
+  def clone_max
+    @property_hash[:clone_max]
+  end
+
+  def clone_node_max
+    @property_hash[:clone_node_max]
+  end
+
+  def notify_clones
+    @property_hash[:notify_clones]
+  end
+
+  def globally_unique
+    @property_hash[:globally_unique]
+  end
+
+  def ordered
+    @property_hash[:ordered]
+  end
+
+  def interleave
+    @property_hash[:interleave]
+  end
+
+  # Our setters.  Setters are used when the
+  # resource already exists so we just update the current value in the property
+  # hash and doing this marks it to be flushed.
+
+  def primitive=(should)
+    @property_hash[:primitive] = should
+  end
+
+  def clone_max=(should)
+    @property_hash[:clone_max] = should
+  end
+
+  def clone_node_max=(should)
+    @property_hash[:clone_node_max] = should
+  end
+
+  def notify_clones=(should)
+    @property_hash[:notify_clones] = should
+  end
+
+  def globally_unique=(should)
+    @property_hash[:globally_unique] = should
+  end
+
+  def ordered=(should)
+    @property_hash[:ordered] = should
+  end
+
+  def interleave=(should)
+    @property_hash[:interleave] = should
+  end
+
+  def exists?
+    @property_hash[:existing_resource] == :true
+  end
+
+  # Flush is triggered on anything that has been detected as being
+  # modified in the property_hash.  It generates a temporary file with
+  # the updates that need to be made.  The temporary file is then used
+  # as stdin for the crm command.
+  def flush
+    unless @property_hash.empty?     
+      if @property_hash[:existing_resource] == :false
+        debug ('Creating clone resource')
+        cmd = [ command(:pcs), 'resource', 'clone', "#{@property_hash[:primitive]}" ]
+        cmd << "clone-max=#{@property_hash[:clone_max]}" if @property_hash[:clone_max]
+        cmd << "clone-node-max=#{@property_hash[:clone_node_max]}" if @property_hash[:clone_node_max]
+        cmd << "notify=#{@property_hash[:notify_clones]}" if @property_hash[:notify_clones]
+        cmd << "globally-unique=#{@property_hash[:globally_unique]}" if @property_hash[:globally_unique]
+        cmd << "ordered=#{@property_hash[:ordered]}" if @property_hash[:ordered]
+        cmd << "interleave=#{@property_hash[:interleave]}" if @property_hash[:interleave]
+        raw, status = Puppet::Provider::Pacemaker::run_pcs_command(cmd)
+      else
+        debug ('Updating clone resource')
+        # pcs versions earlier than 0.9.116 do not allow updating a cloned
+        # resource. Being conservative, we will unclone then create a new clone
+        # with the new parameters.
+        Puppet::Provider::Pacemaker::run_pcs_command([command(:pcs), 'resource', 'unclone', @resource[:primitive]])
+        cmd = [ command(:pcs), 'resource', 'clone', "#{@property_hash[:primitive]}" ]
+        cmd << "clone-max=#{@property_hash[:clone_max]}" if @property_hash[:clone_max]
+        cmd << "clone-node-max=#{@property_hash[:clone_node_max]}" if @property_hash[:clone_node_max]
+        cmd << "notify=#{@property_hash[:notify_clones]}" if @property_hash[:notify_clones]
+        cmd << "globally-unique=#{@property_hash[:globally_unique]}" if @property_hash[:globally_unique]
+        cmd << "ordered=#{@property_hash[:ordered]}" if @property_hash[:ordered]
+        cmd << "interleave=#{@property_hash[:interleave]}" if @property_hash[:interleave]
+        raw, status = Puppet::Provider::Pacemaker::run_pcs_command(cmd)
+      end
+    end
+  end
+end
+

--- a/lib/puppet/type/cs_clone.rb
+++ b/lib/puppet/type/cs_clone.rb
@@ -1,0 +1,81 @@
+module Puppet
+  newtype(:cs_clone) do
+    @doc = "Type for manipulating corosync/pacemaker resource clone.
+      More information on Corosync/Pacemaker colocation can be found here:
+
+      * http://www.clusterlabs.org/doc/en-US/Pacemaker/1.1/html/Clusters_from_Scratch/_ensuring_resources_run_on_the_same_host.html"
+
+    ensurable
+
+    newparam(:name) do
+      desc "Identifier of the location entry.  This value needs to be unique
+        across the entire Corosync/Pacemaker configuration since it doesn't have
+        the concept of name spaces per type."
+
+      isnamevar
+    end
+
+    newproperty(:primitive) do
+      desc "The corosync resource primitive to be cloned.  "
+    end
+
+    newproperty(:clone_max) do
+      desc "How many copies of the resource to start.
+        Defaults to the number of nodes in the cluster."
+    end
+    newproperty(:clone_node_max) do
+      desc "How many copies of the resource can be started on a single node.
+      Defaults to 1."
+    end
+
+    newproperty(:notify_clones) do
+      desc "When stopping or starting a copy of the clone, tell all the other copies beforehand
+        and when the action was successful.
+        Allowed values: true, false"
+
+        newvalues(:true, :false)
+    end
+
+    newproperty(:globally_unique) do
+      desc "Does each copy of the clone perform a different function?
+        Allowed values: true, false"
+
+        newvalues(:true, :false)
+    end
+
+    newproperty(:ordered) do
+      desc "Should the copies be started in series (instead of in parallel). Allowed values: true, false"
+
+        newvalues(:true, :false)
+    end
+
+    newproperty(:interleave) do
+      desc "Changes the behavior of ordering constraints (between clones/masters) so that instances can start/stop
+        as soon as their peer instance has (rather than waiting for every instance of the other clone has).
+        Allowed values: true, false"
+
+        newvalues(:true, :false)
+    end
+
+    newparam(:cib) do
+      desc "Corosync applies its configuration immediately. Using a CIB allows
+        you to group multiple primitives and relationships to be applied at
+        once. This can be necessary to insert complex configurations into
+        Corosync correctly.
+
+        This paramater sets the CIB this colocation should be created in. A
+        cs_shadow resource with a title of the same name as this value should
+        also be added to your manifest."
+    end
+
+    autorequire(:cs_shadow) do
+      [ @parameters[:cib] ]
+    end
+
+    autorequire(:service) do
+      [ 'corosync' ]
+    end
+
+  end
+end
+

--- a/spec/unit/puppet/provider/cs_clone_crm_spec.rb
+++ b/spec/unit/puppet/provider/cs_clone_crm_spec.rb
@@ -1,0 +1,125 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:cs_clone).provider(:crm) do
+  before do
+    described_class.stubs(:command).with(:crm).returns 'crm'
+  end
+
+  context 'when getting instances' do
+    let :instances do
+
+      test_cib = <<-EOS
+        <cib>
+        <configuration>
+          <resources>
+            <clone id="p_keystone-clone">
+              <primitive class="systemd" id="p_keystone" type="openstack-keystone">
+                <meta_attributes id="p_keystone-meta_attributes"/>
+                <operations/>
+              </primitive>
+              <meta_attributes id="p_keystone-clone-meta"/>
+            </clone>
+          </resources>
+        </configuration>
+        </cib>
+      EOS
+
+      described_class.expects(:block_until_ready).returns(nil)
+      if Puppet::PUPPETVERSION.to_f < 3.4
+        Puppet::Util::SUIDManager.expects(:run_and_capture).with(['crm', 'configure', 'show', 'xml']).at_least_once.returns([test_cib, 0])
+      else
+        Puppet::Util::Execution.expects(:execute).with(['crm', 'configure', 'show', 'xml']).at_least_once.returns(
+          Puppet::Util::Execution::ProcessOutput.new(test_cib, 0)
+        )
+      end
+      instances = described_class.instances
+    end
+
+    it 'should have an instance for each <clone>' do
+      expect(instances.count).to eq(1)
+    end
+
+    describe 'each instance' do
+      let :instance do
+        instances.first
+      end
+
+      it "is a kind of #{described_class.name}" do
+        expect(instance).to be_a_kind_of(described_class)
+      end
+
+      it "is named by the <primitive>'s id attribute" do
+        expect(instance.name).to eq("p_keystone-clone")
+      end
+    end
+  end
+
+  context 'when flushing' do
+    def expect_update(pattern)
+      instance.expects(:crm).with { |*args|
+        if args.slice(0..2) == ['configure', 'load', 'update']
+          expect(File.read(args[3])).to match(pattern)
+          true
+        else
+          false
+        end
+      }
+    end
+
+    let :resource do
+      Puppet::Type.type(:cs_clone).new(
+        :name      => 'p_keystone-clone',
+        :provider  => :crm,
+        :primitive => 'p_keystone',
+        :ensure    => :present)
+    end
+
+    let :instance do
+      instance = described_class.new(resource)
+      instance.create
+      instance
+    end
+
+    it 'creates clone' do
+        expect_update(/clone p_keystone-clone p_keystone/)
+        instance.flush
+    end
+
+    it 'sets max clones' do
+      instance.clone_max = 3
+      expect_update(/clone-max=3/)
+      instance.flush
+    end
+
+    it 'sets max node clones' do
+      instance.clone_node_max = 3
+      expect_update(/clone-node-max=3/)
+      instance.flush
+    end
+    
+    it 'sets notify_clones' do
+      instance.notify_clones = :true
+      expect_update(/notify=true/)
+      instance.flush
+    end
+
+    it 'sets globally unique' do
+      instance.globally_unique = :true
+      expect_update(/globally-unique=true/)
+      instance.flush
+    end
+
+    it 'sets ordered' do
+      instance.ordered = :true
+      expect_update(/ordered=true/)
+      instance.flush
+    end
+
+    it 'sets interleave' do
+      instance.interleave = :true
+      expect_update(/interleave=true/)
+      instance.flush
+    end
+  end
+
+end

--- a/spec/unit/puppet/provider/cs_clone_pcs_spec.rb
+++ b/spec/unit/puppet/provider/cs_clone_pcs_spec.rb
@@ -1,0 +1,132 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:cs_clone).provider(:pcs) do
+  before do
+    described_class.stubs(:command).with(:pcs).returns 'pcs'
+  end
+
+  context 'when getting instances' do
+    let :instances do
+
+      test_cib = <<-EOS
+        <cib>
+        <configuration>
+          <resources>
+            <clone id="p_keystone-clone">
+              <primitive class="systemd" id="p_keystone" type="openstack-keystone">
+                <meta_attributes id="p_keystone-meta_attributes"/>
+                <operations/>
+              </primitive>
+              <meta_attributes id="p_keystone-clone-meta"/>
+            </clone>
+          </resources>
+        </configuration>
+        </cib>
+      EOS
+
+      described_class.expects(:block_until_ready).returns(nil)
+      if Puppet::PUPPETVERSION.to_f < 3.4
+        Puppet::Util::SUIDManager.expects(:run_and_capture).with(['pcs', 'cluster', 'cib']).at_least_once.returns([test_cib, 0])
+      else
+        Puppet::Util::Execution.expects(:execute).with(['pcs', 'cluster', 'cib'], {:failonfail => true}).at_least_once.returns(
+          Puppet::Util::Execution::ProcessOutput.new(test_cib, 0)
+        )
+      end
+      instances = described_class.instances
+    end
+
+    it 'should have an instance for each <clone>' do
+      expect(instances.count).to eq(1)
+    end
+
+    describe 'each instance' do
+      let :instance do
+        instances.first
+      end
+
+      it "is a kind of #{described_class.name}" do
+        expect(instance).to be_a_kind_of(described_class)
+      end
+
+      it "is named by the <primitive>'s id attribute" do
+        expect(instance.name).to eq("p_keystone-clone")
+      end
+    end
+  end
+
+  context 'when flushing' do
+    def expect_update(pattern)
+      if Puppet::PUPPETVERSION.to_f < 3.4
+        Puppet::Util::SUIDManager.expects(:run_and_capture).with { |*args|
+          cmdline=args[0].join(" ")
+          expect(cmdline).to match(pattern)
+          true
+        }.at_least_once.returns(['', 0])
+      else
+        Puppet::Util::Execution.expects(:execute).with{ |*args|
+          cmdline=args[0].join(" ")
+          expect(cmdline).to match(pattern)
+          true
+        }.at_least_once.returns(
+          Puppet::Util::Execution::ProcessOutput.new('', 0)
+        )
+      end
+    end
+
+    let :resource do
+      Puppet::Type.type(:cs_clone).new(
+        :name      => 'p_keystone',
+        :provider  => :pcs,
+        :primitive => 'p_keystone',
+        :ensure    => :present)
+    end
+
+    let :instance do
+      instance = described_class.new(resource)
+      instance.create
+      instance
+    end
+
+    it 'creates clone' do
+        expect_update(/pcs resource clone p_keystone/)
+        instance.flush
+    end
+
+    it 'sets max clones' do
+      instance.clone_max = 3
+      expect_update(/clone-max=3/)
+      instance.flush
+    end
+
+    it 'sets max node clones' do
+      instance.clone_node_max = 3
+      expect_update(/clone-node-max=3/)
+      instance.flush
+    end
+    
+    it 'sets notify_clones' do
+      instance.notify_clones = :true
+      expect_update(/notify=true/)
+      instance.flush
+    end
+
+    it 'sets globally unique' do
+      instance.globally_unique = :true
+      expect_update(/globally-unique=true/)
+      instance.flush
+    end
+
+    it 'sets ordered' do
+      instance.ordered = :true
+      expect_update(/ordered=true/)
+      instance.flush
+    end
+
+    it 'sets interleave' do
+      instance.interleave = :true
+      expect_update(/interleave=true/)
+      instance.flush
+    end
+  end
+
+end

--- a/spec/unit/puppet/type/cs_clone_spec.rb
+++ b/spec/unit/puppet/type/cs_clone_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:cs_clone) do
+  subject do
+    Puppet::Type.type(:cs_clone)
+  end
+
+  it "should have a 'name' parameter" do
+    expect(subject.new(:name => "mock_clone")[:name]).to eq("mock_clone")
+  end
+
+  describe "basic structure" do
+    it "should be able to create an instance" do
+      provider_class = Puppet::Type::Cs_clone.provider(Puppet::Type::Cs_clone.providers[0])
+      Puppet::Type::Cs_clone.expects(:defaultprovider).returns(provider_class)
+
+      expect(subject.new(:name => "mock_clone")).to_not be_nil
+    end
+
+    [:name, :cib].each do |param|
+      it "should have a #{param} parameter" do
+        expect(subject.validparameter?(param)).to be_truthy
+      end
+
+      it "should have documentation for its #{param} parameter" do
+        expect(subject.paramclass(param).doc).to be_instance_of(String)
+      end
+    end
+
+    [:primitive, :clone_max, :clone_node_max, :notify_clones, :globally_unique,
+     :ordered, :interleave].each do |property|
+      it "should have a #{property} property" do
+        expect(subject.validproperty?(property)).to be_truthy
+      end
+
+      it "should have documentation for its #{property} property" do
+        expect(subject.propertybyname(property).doc).to be_instance_of(String)
+      end
+    end
+  end
+
+  describe "when validating attributes" do
+    [:notify_clones, :globally_unique, :ordered, :interleave].each do |attribute|
+      it "should validate that the #{attribute} attribute can be true/false" do
+        [true, false].each do |value|
+          expect(subject.new(
+            :name     => "mock_clone",
+            attribute => value
+          )[attribute]).to eq(value.to_s.to_sym)
+        end
+      end
+
+      it "should validate that the #{attribute} attribute cannot be other values" do
+        ["fail", 42].each do |value|
+          expect{subject.new(
+            :name     => "mock_clone",
+            attribute => "fail"
+          ) }.to raise_error Puppet::Error, /(true|false)/
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is a complete cs_clone type, including providers for both pcs
and crm, as well as spec tests. It is based on PR#83, and has been
successfully tested. crm tests on a real cluster have not been as
complete as with pcs, so any input would be welcome.