### PR TITLE
Add votequorum setting to corosync.conf

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -68,6 +68,15 @@
 # [*token*]
 #   Time (in ms) to wait for a token
 #
+# [*set_votequorum*]
+#   Set to true if corosync_votequorum should be used as quorum provider.
+#   Defaults to false.
+#
+# [*quorum_members*]
+#   Array of quorum member hostname. This is required if set_votequorum
+#   is set to true.
+#   Defaults to undef,
+#
 # === Examples
 #
 #  class { 'corosync':
@@ -100,7 +109,13 @@ class corosync(
   $ttl               = $::corosync::params::ttl,
   $packages          = $::corosync::params::packages,
   $token             = $::corosync::params::token,
+  $set_votequorum    = $::corosync::params::set_votequorum,
+  $quorum_members    = ['localhost'],
 ) inherits ::corosync::params {
+
+  if $set_votequorum and !$quorum_members {
+    fail('set_votequorum is true, but no quorum_members have been passed.')
+  }
 
   if ! is_bool($enable_secauth) {
     validate_re($enable_secauth, '^(on|off)$')

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -14,4 +14,19 @@ class corosync::params {
   $ttl               = false
   $packages          = ['corosync', 'pacemaker']
   $token             = 3000
+
+  case $::osfamily {
+    'RedHat': {
+      $set_votequorum = true
+    }
+
+    'Debian': {
+      $set_votequorum = false
+    }
+
+    default: {
+      fail('Not supported OS')
+    }
+  }
+
 }

--- a/spec/classes/corosync_spec.rb
+++ b/spec/classes/corosync_spec.rb
@@ -1,17 +1,95 @@
 require 'spec_helper'
 
-describe 'corosync', :type => :class do
-  context "on a Debian OS" do
-    let :facts do
-      {
-        :processorcount => '3',
-        :ipaddress      => '127.0.0.1',
-        :osfamily       => 'Debian'
-      }
-    end
-    let :params do
-      { :multicast_address => '239.1.1.2' }
-    end
+describe 'corosync' do
+
+  let :params do
+    { :set_votequorum => false,
+      :multicast_address => '239.1.1.2' }
+  end
+
+  shared_examples_for 'corosync' do
     it { is_expected.to compile }
+
+    context 'when set_quorum is true and quorum_members are set' do
+      before :each do
+        params.merge!(
+          { :set_votequorum => true,
+            :quorum_members => ['node1.test.org', 'node2.test.org'] }
+        )
+      end
+
+      it 'configures votequorum' do
+        should contain_file('/etc/corosync/corosync.conf').with_content(
+          /nodelist/
+        )
+        should contain_file('/etc/corosync/corosync.conf').with_content(
+          /ring0_addr\: node1\.test\.org/
+        )
+        should contain_file('/etc/corosync/corosync.conf').with_content(
+          /ring0_addr\: node2\.test\.org/
+        )
+      end
+    end
+
+    context 'when set_quorum is true and unicast is used' do
+      before :each do
+        params.merge!(
+          { :set_votequorum => true,
+            :quorum_members => ['node1.test.org', 'node2.test.org'],
+            :multicast_address => 'UNSET',
+            :unicast_addresses => ['192.168.1.1', '192.168.1.2'], }
+        )
+      end
+
+      it 'configures votequorum' do
+        should contain_file('/etc/corosync/corosync.conf').with_content(
+          /nodelist/
+        )
+        should contain_file('/etc/corosync/corosync.conf').with_content(
+          /ring0_addr\: node1\.test\.org/
+        )
+        should contain_file('/etc/corosync/corosync.conf').with_content(
+          /ring0_addr\: node2\.test\.org/
+        )
+      end
+    end
+
+    context 'when set_quorum is true and quorum_members are not set' do
+      before :each do
+        params.merge!(
+          { :set_votequorum => true,
+            :quorum_members => false }
+        )
+      end
+
+      it 'raises error' do
+        expect {
+          is_expected.to compile
+        }.to raise_error(
+            Puppet::Error,
+            /set_votequorum is true, but no quorum_members have been passed./
+        )
+      end
+    end
+  end
+
+  context 'on Debian platforms' do
+    let :facts do
+      { :osfamily       => 'Debian',
+        :processorcount => '3',
+        :ipaddress      => '127.0.0.1' }
+    end
+
+    it_configures 'corosync'
+  end
+
+  context 'on RedHat platforms' do
+    let :facts do
+      { :osfamily       => 'RedHat',
+        :processorcount => '3',
+        :ipaddress      => '127.0.0.1' }
+    end
+
+    it_configures 'corosync'
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,1 +1,5 @@
 require 'puppetlabs_spec_helper/module_spec_helper'
+
+RSpec.configure do |c|
+  c.alias_it_should_behave_like_to :it_configures, 'configures'
+end

--- a/templates/corosync.conf.erb
+++ b/templates/corosync.conf.erb
@@ -52,3 +52,18 @@ aisexec {
   user:  root
   group: root
 }
+
+<% if @set_votequorum -%>
+quorum {
+  provider: corosync_votequorum
+}
+
+nodelist {
+<% [@quorum_members].flatten.each_index do |i| -%>
+  node {
+    ring0_addr: <%= [@quorum_members].flatten[i] %>
+    nodeid: <%= i %>
+  }
+<% end -%>
+}
+<% end -%>

--- a/templates/corosync.conf.udpu.erb
+++ b/templates/corosync.conf.udpu.erb
@@ -51,3 +51,18 @@ aisexec {
   user:  root
   group: root
 }
+
+<% if @set_votequorum -%>
+quorum {
+  provider: corosync_votequorum
+}
+
+nodelist {
+<% [@quorum_members].flatten.each_index do |i| -%>
+  node {
+    ring0_addr: <%= [@quorum_members].flatten[i] %>
+    nodeid: <%= i %>
+  }
+<% end -%>
+}
+<% end -%>


### PR DESCRIPTION
This is required to run Corosync 2.0 with Pacemaker >= 1.1.8 via pcs.
See: http://clusterlabs.org/doc/en-US/Pacemaker/1.1-pcs/html/Clusters_from_Scratch/ch03.html