### PR TITLE
Ensure node IDs for votequorum are not "0"

### DIFF
--- a/templates/corosync.conf.erb
+++ b/templates/corosync.conf.erb
@@ -62,7 +62,7 @@ nodelist {
 <% [@quorum_members].flatten.each_index do |i| -%>
   node {
     ring0_addr: <%= [@quorum_members].flatten[i] %>
-    nodeid: <%= i %>
+    nodeid: <%= i+1 %>
   }
 <% end -%>
 }

--- a/templates/corosync.conf.udpu.erb
+++ b/templates/corosync.conf.udpu.erb
@@ -61,7 +61,7 @@ nodelist {
 <% [@quorum_members].flatten.each_index do |i| -%>
   node {
     ring0_addr: <%= [@quorum_members].flatten[i] %>
-    nodeid: <%= i %>
+    nodeid: <%= i+1 %>
   }
 <% end -%>
 }


### PR DESCRIPTION
According to Andrew Beekhof, the original author of Pacemaker, the "node
id" field for nodes in Corosync's votequorum configuration is not to be
0. In that case, Corosync will refuse to start on certain hosts:

Jan 27 13:54:31 cloud11 pacemakerd[51961]:     crit:
corosync_initialize_nodelist: Nodes 1 and 0 share the same name
'cloud11': shutting down

Here is Andrew's official statement:

http://oss.clusterlabs.org/pipermail/pacemaker/2013-September/019526.html

This commit ensures that the ID is never 0.