### PR TITLE
Fixes error detection

### DIFF
--- a/spec/classes/corosync_spec.rb
+++ b/spec/classes/corosync_spec.rb
@@ -65,10 +65,7 @@ describe 'corosync' do
       it 'raises error' do
         expect {
           is_expected.to compile
-        }.to raise_error(
-            Puppet::Error,
-            /set_votequorum is true, but no quorum_members have been passed./
-        )
+        }.to raise_error(/set_votequorum is true, but no quorum_members have been passed./)
       end
     end
   end


### PR DESCRIPTION
rspec-puppet behaviour for errors changed to raise a non Puppet error, easier to just match the regex (see rodjek/rspec-puppet#217 for details)

All PR's will fail until this is merged...