### PR TITLE
param mcastport is still used when using broadcast mode.

### DIFF
--- a/templates/corosync.conf.erb
+++ b/templates/corosync.conf.erb
@@ -20,8 +20,8 @@ totem {
     broadcast:   yes
 <% else -%>
     mcastaddr:   <%= [@multicast_address].flatten[i] %>
-    mcastport:   <%= [@port].flatten[i] %>
 <% end -%>
+    mcastport:   <%= [@port].flatten[i] %>
 <% if @ttl -%>
     ttl:         <%= @ttl %>
 <% end -%>


### PR DESCRIPTION
when using broadcast mode, the UDP port used by broadcast traffic is set
by the mcastport parameter.

Moved parameter in template, so that it applies to both multicast and
broadcast.