### PR TITLE
Bugfix - crmsh cs_location provider

### DIFF
--- a/lib/puppet/provider/cs_location/crm.rb
+++ b/lib/puppet/provider/cs_location/crm.rb
@@ -28,7 +28,7 @@ Puppet::Type.type(:cs_location).provide(:crm, :parent => Puppet::Provider::Crmsh
         :name       => items['id'],
         :ensure     => :present,
         :primitive  => items['rsc'],
-        :node_name  => items['node_name'],
+        :node_name  => items['node'],
         :score      => items['score'],
         :provider   => self.name
       }


### PR DESCRIPTION
Incorrect element name is being read from the xml dump:
<rsc_location id="confluence_service_location_1"
node="htf-foo" rsc="confluence" score="201"/>

:node_name  => items['node_name']
should be
:node_name  => items['node']