### PR TITLE
Pin rspec to 3.1.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 group :development, :unit_tests do
   gem 'rake',                   :require => false
+  gem 'rspec', '~>3.1.0',       :require => false
   gem 'rspec-puppet', '~>2.0',  :require => false
   gem 'puppetlabs_spec_helper', :require => false
   gem 'puppet-lint',            :require => false


### PR DESCRIPTION
Puppet 2.7 and ruby 1.8.7 combined have a flaw that results in issues
with the latest version of rspec 3. This change pins rspec to 3.1.x
until we can drop support for puppet 2.7 and ruby 1.8.7.